### PR TITLE
Fix module load error from incorrect module name babel --> babel-core

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,4 +1,4 @@
-require('babel/register')({
+require('babel-core/register')({
 	stage: 0
 });
 


### PR DESCRIPTION
Was throwing error on npm start when it tried loading babel/register. The module 'babel' does not exist.
