### PR TITLE
warning still exists with NODE_ENV=production

### DIFF
--- a/webpack.production.config.js
+++ b/webpack.production.config.js
@@ -30,6 +30,11 @@ module.exports = {
 				warnings: false,
 				screw_ie8: true
 			}
+		}),
+		new webpack.DefinePlugin({
+		      	'process.env':{
+		        	'NODE_ENV': JSON.stringify('production')
+		      	}
 		})
 	],
 	module: {


### PR DESCRIPTION
http://dev.topheman.com/make-your-react-production-minified-version-with-webpack/
https://github.com/facebook/react/issues/6479
