### PR TITLE
A few small fixes

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,17 @@
 {
-  "presets": ["es2015", "stage-0", "react"],
+  "presets": ["es2015", "react", "stage-0"],
   "plugins": [["transform-object-assign"]],
+  "env": {
+    "development": {
+      "plugins": [
+        ["react-transform", {
+          "transforms": [{
+            "transform": "react-transform-hmr",
+            "imports": ["react"],
+            "locals": ["module"]
+          }]
+        }]
+      ]
+    }
+  }
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,12 +1,13 @@
 module.exports = {
-    "extends": "airbnb",
-    "installedESLint": true,
-    "plugins": [
-        "react",
-        "jsx-a11y",
-        "import"
-    ],
-    "rules": {
-			"react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
-		}
+  "parser": "babel-eslint",
+  "extends": "airbnb",
+  "installedESLint": true,
+  "plugins": [
+      "react",
+      "jsx-a11y",
+      "import"
+  ],
+  "rules": {
+		"react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
+	}
 };

--- a/app/components/UserCard.js
+++ b/app/components/UserCard.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const UserCard = ({ user }) => (
   <ul>

--- a/app/components/UserList.js
+++ b/app/components/UserList.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 
 const UserList = ({ users }) => (

--- a/app/configureStore.js
+++ b/app/configureStore.js
@@ -7,8 +7,15 @@ const createStoreWithMiddleware = applyMiddleware(
   thunkMiddleware,
 )(createStore);
 
+// eslint-disable-next-line no-undef
+const initReduxDevTool = (typeof window === 'object' && typeof window.devToolsExtension !== 'undefined') ? window.devToolsExtension() : f => f;
+
 export default function configureStore(initialState) {
-  const store = createStoreWithMiddleware(rootReducer, initialState);
+  const store = createStoreWithMiddleware(
+    rootReducer,
+    initialState,
+    initReduxDevTool,
+  );
 
   if (module.hot) {
     // Enable Webpack hot module replacement for reducers

--- a/app/containers/App.js
+++ b/app/containers/App.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import Helmet from 'react-helmet';
 

--- a/app/containers/Home.js
+++ b/app/containers/Home.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, PureComponent } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import { connect } from 'react-redux';
 import * as UsersActions from '../actions/users';
@@ -28,7 +29,11 @@ class Home extends PureComponent {
       return <p>Failed to fetch users</p>;
     }
 
-    return <UserList users={users.list} />;
+    if (users.readyState === UsersActions.USERS_FETCHED) {
+      return <UserList users={users.list} />;
+    }
+
+    return null;
   }
 
   render() {
@@ -45,7 +50,7 @@ Home.propTypes = {
   dispatch: PropTypes.func.isRequired,
   users: PropTypes.shape({
     readyState: PropTypes.string.isRequired,
-    list: PropTypes.array.isRequired,
+    list: PropTypes.array,
   }).isRequired,
 };
 

--- a/app/containers/Root.js
+++ b/app/containers/Root.js
@@ -1,6 +1,7 @@
 /* globals ENVIRONMENT */
 /* eslint-disable react/no-danger */
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 function renderInitialState(initialState) {
   const innerHtml = `window.INITIAL_STATE = ${JSON.stringify(initialState)}`;
@@ -36,4 +37,3 @@ Root.propTypes = {
 };
 
 export default Root;
-

--- a/app/containers/User.js
+++ b/app/containers/User.js
@@ -1,4 +1,5 @@
-import React, { PropTypes, PureComponent } from 'react';
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import { connect } from 'react-redux';
 import * as UserActions from '../actions/user';
@@ -31,18 +32,25 @@ class User extends PureComponent {
       return <p>Failed to fetch user</p>;
     }
 
-    return <UserCard user={user.info} />;
+    if (user.readyState === UserActions.USER_FETCHED) {
+      return (
+        <div>
+          <Helmet
+            title={user.info.name || ''}
+            meta={[
+              { name: 'description', content: 'User Profile' },
+            ]}
+          />
+          <UserCard user={user.info} />
+        </div>
+      );
+    }
+    return null;
   }
 
   render() {
     return (
       <div>
-        <Helmet
-          title={this.getUser().name || ''}
-          meta={[
-            { name: 'description', content: 'User Profile' },
-          ]}
-        />
         {this.renderUser()}
       </div>
     );

--- a/app/index.js
+++ b/app/index.js
@@ -1,6 +1,7 @@
 import 'isomorphic-fetch';
+
 export serverMiddleware from './Router';
 
 if (module.hot) {
-	module.hot.accept();
+  module.hot.accept();
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "scripts": {
     "start": "node server",
     "start-prod": "npm run build && NODE_ENV=production PORT=3000 node server",
-    "build": "cross-env NODE_ENV=production webpack --config ./webpack.production.config.js --progress"
+    "build": "cross-env NODE_ENV=production webpack --config ./webpack.production.config.js --progress",
+    "test": "eslint app"
   },
   "dependencies": {
     "babel-core": "^6.22.1",

--- a/package.json
+++ b/package.json
@@ -34,9 +34,11 @@
     "babel-preset-react": "^6.22.0",
     "babel-preset-stage-0": "^6.22.0",
     "cross-env": "^3.1.4",
+    "del": "^2.2.2",
     "express": "^4.14.1",
     "history": "^4.5.1",
     "isomorphic-fetch": "^2.2.1",
+    "prop-types": "^15.5.8",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-helmet": "^4.0.0",
@@ -49,10 +51,10 @@
     "webpack-hot-middleware": "^2.16.1"
   },
   "devDependencies": {
+    "babel-eslint": "^7.2.2",
     "babel-loader": "^6.2.10",
     "babel-plugin-react-transform": "^2.0.2",
     "babel-plugin-transform-object-assign": "^6.22.0",
-    "del": "^2.2.2",
     "eslint": "^3.15.0",
     "eslint-config-airbnb": "^14.0.0",
     "eslint-plugin-import": "^2.2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,19 +22,6 @@ module.exports = {
       test: /\.js?$/,
       loader: 'babel-loader',
       include: path.join(__dirname, 'app'),
-      query: {
-        plugins: [
-          ['react-transform', {
-            transforms: [{
-              transform: 'react-transform-hmr',
-              // If you use React Native, pass 'react-native' instead:
-              imports: ['react'],
-              // This is important for Webpack HMR:
-              locals: ['module'],
-            }],
-          }],
-        ],
-      },
     }],
   },
 };


### PR DESCRIPTION
Hi @DominicTobias 

I came across this repo and liked it for its simplicity. I took the freedom to fix a few things (list below) that were throwing an error.

- Added preset babel-eslint to the .eslintsrc. The way 'serverMiddleware' was exported made eslint trigger a prefer-default-export issue
- Added Redux Devtools
- parseQuery will soon be depracated in Webpack so to fix the warning message react-transform had to be moved from webpack to .babelrc as per the official guide
- Swapped presets order in the .babelrc file so that is now possible to use state = {} without invoking the constructor method
- Migrated to prop-types. React has deprecated PropTypes so a separate package needs to be used. Although the warning is still active due to some dependencies still using the old PropTypes
- Fixed an issue in User.js where this.getUser().info was undefined and threw an error
- Fixed an issue in User.js where user.info was undefined and threw an error (this was happening with a slow response from the api). The UserCard component was mounting before the request was fully executed